### PR TITLE
Fix macOS setup, MPS support, and Python 3.11 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,27 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _check_venv() -> None:
+    """Abort early if setup is not running inside a virtual environment.
+
+    Installing into a system or user Python risks package-version conflicts
+    (e.g. torch / sentence-transformers) that are hard to undo.  A venv keeps
+    the install fully isolated and is the only supported setup path.
+    """
+    if sys.prefix == sys.base_prefix:
+        print(
+            "\n[error] Arignan setup must be run inside a Python virtual environment.\n"
+            "Installing into the system or user Python can corrupt existing packages.\n\n"
+            "Create and activate a virtual environment first:\n"
+            "  python3 -m venv .venv\n"
+            "  source .venv/bin/activate    # macOS / Linux\n"
+            "  .venv\\Scripts\\activate       # Windows\n\n"
+            "Then rerun:  python setup.py [options]",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+
 def _choose_app_home_action(inspection) -> str:
     if not inspection.exists or not inspection.entries:
         return "fresh"
@@ -80,6 +101,7 @@ def main() -> int:
     if is_packaging_invocation(sys.argv):
         setuptools_setup()
         return 0
+    _check_venv()
     from arignan.setup_flow import render_summary, run_setup
 
     args = build_parser().parse_args()

--- a/src/arignan/cli.py
+++ b/src/arignan/cli.py
@@ -640,3 +640,7 @@ def render_retrieved_context(hits) -> str:
         if index < len(hits):
             lines.append("")
     return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/arignan/compute.py
+++ b/src/arignan/compute.py
@@ -15,7 +15,11 @@ def preferred_torch_device(sink: callable | None = None) -> str:
     #         sink("Torch Imported")
     # except ImportError:  # pragma: no cover
     #     return "cpu"
-    return "cuda" if torch.cuda.is_available() else "cpu"
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
 
 
 def release_torch_cuda_memory() -> bool:

--- a/src/arignan/markdown/writer.py
+++ b/src/arignan/markdown/writer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Protocol
 
@@ -133,7 +133,7 @@ class HeuristicArtifactWriter:
 class LLMArtifactWriter:
     generator: LocalTextGenerator
     fallback: ArtifactWriter
-    prompts: PromptSet = DEFAULT_PROMPT_SET
+    prompts: PromptSet = field(default_factory=lambda: DEFAULT_PROMPT_SET)
     trace_sink: ModelTraceCollector | None = None
     progress_sink: Callable[[str], None] | None = None
     exception_logger: SessionExceptionLogger | None = None

--- a/src/arignan/setup_flow.py
+++ b/src/arignan/setup_flow.py
@@ -399,12 +399,17 @@ def create_launchers(root: Path | None = None, app_home: Path | None = None) -> 
     bin_dir = resolved_root / "bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
 
-    python_executable = Path(sys.executable).resolve()
+    # Use absolute() rather than resolve() so that the venv symlink (e.g.
+    # .venv/bin/python3.11) is preserved as-is.  resolve() would follow the
+    # symlink all the way to the real interpreter (e.g. the Homebrew Python),
+    # which lives outside the venv and doesn't have this package installed.
+    python_executable = Path(sys.executable).absolute()
     app_home_arg_windows = f' --app-home "{Path(app_home).resolve()}"' if app_home is not None else ""
     app_home_arg_posix = f" --app-home {_quote_posix_argument(str(Path(app_home).resolve()))}" if app_home is not None else ""
     windows_launcher = bin_dir / "arignan.cmd"
     windows_launcher.write_text(
         "@echo off\r\n"
+        "set TOKENIZERS_PARALLELISM=false\r\n"
         f"\"{python_executable}\" -m arignan.cli{app_home_arg_windows} %*\r\n",
         encoding="utf-8",
     )
@@ -412,6 +417,7 @@ def create_launchers(root: Path | None = None, app_home: Path | None = None) -> 
     posix_launcher = bin_dir / "arignan"
     posix_launcher.write_text(
         "#!/usr/bin/env sh\n"
+        "export TOKENIZERS_PARALLELISM=false\n"
         f"{_quote_posix_argument(str(python_executable))} -m arignan.cli{app_home_arg_posix} \"$@\"\n",
         encoding="utf-8",
     )
@@ -436,6 +442,11 @@ def run_setup(
     effective_embedding_model = DEFAULT_LIGHT_EMBEDDING_MODEL_REPO_ID if lightweight else None
     effective_reranker_model = DEFAULT_LIGHT_RERANKER_MODEL_REPO_ID if lightweight else None
     _emit(progress, "[1/4] Installing Python package...")
+    try:
+        existing_version = metadata.version("open-arignan")
+        _emit(progress, f"Existing open-arignan {existing_version} detected in this environment; reinstalling.")
+    except metadata.PackageNotFoundError:
+        pass
     target = install_package(root=root, dev=dev)
     verify_required_ml_runtime()
     _emit(progress, "[2/4] Initializing local Arignan state...")

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import subprocess
+import sys
+
 from arignan.cli import build_parser, main
 
 
@@ -12,6 +15,21 @@ def test_root_help_is_readable_and_avoids_subparser_ellipsis() -> None:
     assert "-gui" in help_text
     assert "load" in help_text
     assert "ask" in help_text
+
+
+def test_cli_module_is_runnable_via_python_m(tmp_path) -> None:
+    # The shell launcher calls `python -m arignan.cli`.  Verify that the
+    # __main__ guard is present so the invocation actually calls main()
+    # rather than silently importing the module and exiting.
+    result = subprocess.run(
+        [sys.executable, "-m", "arignan.cli", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "usage: arignan" in result.stdout
+    assert "load" in result.stdout
+    assert "ask" in result.stdout
 
 
 def test_gui_flag_dispatches_to_gui_launcher(monkeypatch, tmp_path) -> None:

--- a/tests/unit/test_setup_flow.py
+++ b/tests/unit/test_setup_flow.py
@@ -25,6 +25,7 @@ from arignan.setup_flow import (
     render_summary,
     resolve_ollama_model_id,
     resolve_model_repo_id,
+    run_setup,
     sanitize_model_id,
     verify_required_ml_runtime,
 )
@@ -55,6 +56,31 @@ def test_install_package_uses_no_deps_to_avoid_resolving_user_environment(tmp_pa
             True,
         )
     ]
+
+
+def test_run_setup_logs_existing_installation_before_reinstalling(tmp_path: Path, monkeypatch) -> None:
+    progress_messages: list[str] = []
+
+    # Simulate an already-installed version of the package.
+    monkeypatch.setattr("arignan.setup_flow.metadata.version", lambda _name: "0.9.0")
+
+    # Stub out everything that does real work so the test stays fast.
+    monkeypatch.setattr("arignan.setup_flow.install_package", lambda **_kw: ".")
+    monkeypatch.setattr("arignan.setup_flow.verify_required_ml_runtime", lambda: None)
+    monkeypatch.setattr("arignan.setup_flow.download_required_models", lambda *_a, **_kw: tmp_path / "models")
+    monkeypatch.setattr(
+        "arignan.setup_flow.create_launchers",
+        lambda **_kw: (tmp_path / "bin", tmp_path / "bin" / "arignan.cmd", tmp_path / "bin" / "arignan"),
+    )
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    run_setup(app_home=tmp_path / ".arignan", progress=progress_messages.append)
+
+    reinstall_notice = next(
+        (m for m in progress_messages if "0.9.0" in m and "reinstalling" in m),
+        None,
+    )
+    assert reinstall_notice is not None, f"Expected reinstall notice in progress messages: {progress_messages}"
 
 
 def test_create_launchers_writes_bin_scripts(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_setup_flow.py
+++ b/tests/unit/test_setup_flow.py
@@ -65,9 +65,14 @@ def test_create_launchers_writes_bin_scripts(tmp_path: Path, monkeypatch) -> Non
     assert bin_dir == tmp_path / "bin"
     assert windows_launcher.exists()
     assert posix_launcher.exists()
-    assert "-m arignan.cli" in windows_launcher.read_text(encoding="utf-8")
-    assert "-m arignan.cli" in posix_launcher.read_text(encoding="utf-8")
-    assert "--app-home" not in windows_launcher.read_text(encoding="utf-8")
+    win_text = windows_launcher.read_text(encoding="utf-8")
+    posix_text = posix_launcher.read_text(encoding="utf-8")
+    assert "-m arignan.cli" in win_text
+    assert "-m arignan.cli" in posix_text
+    assert "--app-home" not in win_text
+    # Both launchers must silence the HuggingFace tokenizers fork warning.
+    assert "TOKENIZERS_PARALLELISM=false" in win_text
+    assert "TOKENIZERS_PARALLELISM=false" in posix_text
 
 
 def test_create_launchers_can_pin_app_home(tmp_path: Path, monkeypatch) -> None:

--- a/tests/unit/test_setup_py_dispatch.py
+++ b/tests/unit/test_setup_py_dispatch.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
+
+import pytest
 
 
 def _load_setup_module():
@@ -30,3 +33,23 @@ def test_setup_py_parser_accepts_lightweight_flag() -> None:
     args = module.build_parser().parse_args(["--lightweight"])
 
     assert args.lightweight is True
+
+
+def test_check_venv_raises_when_not_in_venv(monkeypatch) -> None:
+    module = _load_setup_module()
+    # Simulate system Python: prefix == base_prefix means no venv is active.
+    monkeypatch.setattr(sys, "prefix", sys.base_prefix)
+
+    with pytest.raises(SystemExit) as exc_info:
+        module._check_venv()
+
+    assert exc_info.value.code == 1
+
+
+def test_check_venv_passes_when_inside_venv(monkeypatch) -> None:
+    module = _load_setup_module()
+    # Simulate an active venv: prefix differs from base_prefix.
+    monkeypatch.setattr(sys, "prefix", "/tmp/fake-venv")
+
+    # Should return normally without raising.
+    module._check_venv()


### PR DESCRIPTION
**MPS support for Apple Silicon**

the embedding model and reranker were always falling back to CPU on Mac because `preferred_torch_device()` only checked for CUDA and nothing else. Added an MPS check so these models 

**Python 3.11 dataclass crash**

`LLMArtifactWriter` in `markdown/writer.py` was using `DEFAULT_PROMPT_SET` as a default value directly in a `slots=True` dataclass. Python 3.11 doesn't allow mutable defaults there so it was throwing a `ValueError` on import, which blocked every single test from even loading. Wrapped it in `field(default_factory=...)` to fix it.

**Setup flow and launcher fixes (Issue #4)**

- The generated `bin/arignan` launcher had the wrong Python path. `create_launchers()` was calling `.resolve()` on `sys.executable` which follows the venv symlink all the way to the real Homebrew Python. That interpreter doesn't have any of the installed packages so the launcher just failed silently. Switched to `.absolute()` which keeps the venv path intact.

- The shell launcher was calling `python -m arignan.cli` but `cli.py` had no `if __name__ == "__main__"` block. So running the module directly just imported it and exited with no output. Added the standard guard to fix this.

- Nothing was stopping someone from running `python setup.py` with their system Python, which would install torch and friends globally and potentially wreck their environment. Added a venv check at the top of `main()` that exits early with a clear message if no venv is active.

- Added `export TOKENIZERS_PARALLELISM=false` to both the POSIX and Windows launchers so the HuggingFace fork warning doesn't show up on every single invocation.

- setup.py now also logs what version is already installed before reinstalling, which makes reruns a lot easier to debug.

**Tests**

All 234 tests pass. Added tests for the three new behaviours that were missing coverage: the venv guard, the existing install detection, and the `python -m` entrypoint.